### PR TITLE
Enable cortex r52 smp in rtu0 of the s32ze

### DIFF
--- a/arch/arm/core/cortex_a_r/CMakeLists.txt
+++ b/arch/arm/core/cortex_a_r/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_library()
 
 zephyr_library_sources(
   exc.S
+  exc_exit.S
   fault.c
   irq_init.c
   reboot.c
@@ -25,4 +26,4 @@ zephyr_library_sources_ifdef(CONFIG_SEMIHOST semihost.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE __aeabi_read_tp.S)
 zephyr_library_sources_ifdef(CONFIG_ARCH_CACHE cache.c)
 zephyr_library_sources_ifdef(CONFIG_USE_SWITCH switch.S)
-zephyr_library_sources_ifndef(CONFIG_USE_SWITCH swap.c swap_helper.S exc_exit.S)
+zephyr_library_sources_ifndef(CONFIG_USE_SWITCH swap.c swap_helper.S)

--- a/arch/arm/core/cortex_a_r/exc.S
+++ b/arch/arm/core/cortex_a_r/exc.S
@@ -42,6 +42,10 @@ GTEXT(z_arm_undef_instruction)
 GTEXT(z_arm_prefetch_abort)
 GTEXT(z_arm_data_abort)
 
+#if defined(CONFIG_FPU_SHARING)
+GTEXT(z_arm_cortex_ar_exit_exc)
+#endif
+
 #ifndef CONFIG_USE_SWITCH
 
 .macro exception_entry mode

--- a/arch/arm/core/cortex_a_r/exc.S
+++ b/arch/arm/core/cortex_a_r/exc.S
@@ -58,19 +58,7 @@ GTEXT(z_arm_cortex_ar_exit_exc)
 	sub sp, #24
 
 #if defined(CONFIG_FPU_SHARING)
-	sub sp, #___fpu_t_SIZEOF
-
-	vmrs r1, fpexc
-	mov r0, #FPEXC_EN
-	vmsr fpexc, r0
-	vmrs r0, fpscr
-
-	mov r2, sp
-	vstmia r2!, {s0-s15}
-#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
-	vstmia r2!, {d16-d31}
-#endif
-	stm r2, {r0, r1}
+	fpu_exc_enter
 #endif
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
@@ -147,17 +135,8 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	cmp r0, #0
 	beq z_arm_exc_exit
 
-	vmrs r1, fpexc
-	mov r0, #FPEXC_EN
-	vmsr fpexc, r0
-	vmrs r0, fpscr
-
-	mov r2, sp
-	vstmia r2!, {s0-s15}
-#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
-	vstmia r2!, {d16-d31}
-#endif
-	stm r2, {r0, r1}
+	add sp, #___fpu_t_SIZEOF
+	fpu_exc_enter
 #endif
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)

--- a/arch/arm/core/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/cortex_a_r/exc_exit.S
@@ -240,6 +240,10 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
 	sub r1, r1, #1
 	strb r1, [r2, #_cpu_offset_to_exc_depth]
 
+#if defined(CONFIG_FPU_SHARING)
+	fpu_exc_exit
+#endif
+
 	/*
 	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
 	 * and return to the current thread.

--- a/arch/arm/core/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/cortex_a_r/exc_exit.S
@@ -27,6 +27,7 @@ GTEXT(z_arm_int_exit)
 GTEXT(z_arm_do_swap)
 GDATA(_kernel)
 
+#ifndef CONFIG_USE_SWITCH
 .macro userspace_exc_exit
 #if defined(CONFIG_USERSPACE)
 	cps #MODE_SVC
@@ -60,49 +61,6 @@ GDATA(_kernel)
 	cps #MODE_SVC
 system_thread_exit\@:
 	pop {r0-r1}
-#endif
-.endm
-
-.macro fpu_exc_exit
-#if defined(CONFIG_FPU_SHARING)
-	/*
-	 * If the floating point context pointer is null, then a context was
-	 * saved so restore the float context from the exception stack frame.
-	 */
-	get_cpu r2
-	ldr r1, [r2, #___cpu_t_fp_ctx_OFFSET]
-	cmp r1, #0
-	beq vfp_restore\@
-
-	/*
-	 * If leaving the last interrupt context, remove the floating point
-	 * context pointer.
-	 */
-	cmp r0, #0
-	moveq r1, #0
-	streq r1, [r2, #___cpu_t_fp_ctx_OFFSET]
-	b vfp_exit\@
-
-vfp_restore\@:
-	add r3, sp, #___fpu_sf_t_fpscr_OFFSET
-	ldm r3, {r1, r2}
-	tst r2, #FPEXC_EN
-	beq vfp_exit\@
-
-	vmsr fpexc, r2
-	vmsr fpscr, r1
-	mov r3, sp
-	vldmia r3!, {s0-s15}
-#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
-	vldmia r3!, {d16-d31}
-#endif
-
-vfp_exit\@:
-	/* Leave the VFP disabled when leaving */
-	mov r1, #0
-	vmsr fpexc, r1
-
-	add sp, sp, #___fpu_t_SIZEOF
 #endif
 .endm
 
@@ -271,3 +229,22 @@ __EXIT_EXC:
 	ldmia sp, {r0-r3, r12, lr}^
 	add sp, #24
 	rfeia sp!
+
+#else /* CONFIG_USE_SWITCH */
+GTEXT(z_arm_cortex_ar_exit_exc)
+SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
+
+	/* decrement exception depth */
+	get_cpu r2
+	ldrb r1, [r2, #_cpu_offset_to_exc_depth]
+	sub r1, r1, #1
+	strb r1, [r2, #_cpu_offset_to_exc_depth]
+
+	/*
+	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
+	 * and return to the current thread.
+	 */
+	ldmia sp, {r0-r3, r12, lr}^
+	add sp, #24
+	rfeia sp!
+#endif

--- a/arch/arm/core/cortex_a_r/fault.c
+++ b/arch/arm/core/cortex_a_r/fault.c
@@ -178,12 +178,12 @@ bool z_arm_fault_undef_instruction_fp(void)
 		if (((_current_cpu->nested == 2)
 				&& (_current->base.user_options & K_FP_REGS))
 			|| ((_current_cpu->nested > 2)
-				&& (spill_esf->undefined & FPEXC_EN))) {
+				&& (spill_esf->fpexc & FPEXC_EN))) {
 			/*
 			 * Spill VFP registers to specified exception stack
 			 * frame
 			 */
-			spill_esf->undefined |= FPEXC_EN;
+			spill_esf->fpexc |= FPEXC_EN;
 			spill_esf->fpscr = __get_FPSCR();
 			z_arm_fpu_caller_save(spill_esf);
 		}
@@ -213,7 +213,7 @@ bool z_arm_fault_undef_instruction(struct arch_esf *esf)
 	 * This is a true undefined instruction and we will be crashing
 	 * so save away the VFP registers.
 	 */
-	esf->fpu.undefined = __get_FPEXC();
+	esf->fpu.fpexc = __get_FPEXC();
 	esf->fpu.fpscr = __get_FPSCR();
 	z_arm_fpu_caller_save(&esf->fpu);
 #endif

--- a/arch/arm/core/cortex_a_r/macro_priv.inc
+++ b/arch/arm/core/cortex_a_r/macro_priv.inc
@@ -26,6 +26,24 @@
         and \rreg0, #TPIDRURO_CURR_CPU
 .endm
 
+.macro fpu_exc_enter
+#if defined(CONFIG_FPU_SHARING)
+	sub sp, #___fpu_t_SIZEOF
+
+	vmrs r1, fpexc
+	mov r0, #FPEXC_EN
+	vmsr fpexc, r0
+	vmrs r0, fpscr
+
+	mov r2, sp
+	vstmia r2!, {s0-s15}
+#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
+	vstmia r2!, {d16-d31}
+#endif /* CONFIG_VFP_FEATURE_REGS_S64_D32 */
+	stm r2, {r0, r1}
+#endif /* defined(CONFIG_FPU_SHARING) */
+.endm
+
 .macro fpu_exc_exit
 #if defined(CONFIG_FPU_SHARING)
 	/*
@@ -44,13 +62,12 @@
 	cmp r0, #0
 	moveq r1, #0
 	streq r1, [r2, #___cpu_t_fp_ctx_OFFSET]
-	b vfp_exit\@
 
 vfp_restore\@:
 	add r3, sp, #___fpu_sf_t_fpscr_OFFSET
 	ldm r3, {r1, r2}
 	tst r2, #FPEXC_EN
-	beq vfp_exit\@
+	beq vfp_disable_exit\@
 
 	vmsr fpexc, r2
 	vmsr fpscr, r1
@@ -59,12 +76,14 @@ vfp_restore\@:
 #ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
 	vldmia r3!, {d16-d31}
 #endif
+	b vfp_exit\@
 
-vfp_exit\@:
-	/* Leave the VFP disabled when leaving */
+vfp_disable_exit\@:
+	/* Disable the VFP disabled when leaving */
 	mov r1, #0
 	vmsr fpexc, r1
-
+	
+vfp_exit\@:
 	add sp, sp, #___fpu_t_SIZEOF
 #endif
 .endm
@@ -78,6 +97,10 @@ vfp_exit\@:
 	cps #MODE_SYS
 	stmdb sp, {r0-r3, r12, lr}^
 	sub sp, #24
+
+#if defined(CONFIG_FPU_SHARING)
+	fpu_exc_enter
+#endif
 
 	/* TODO: EXTRA_EXCEPTION_INFO */
 	mov r0, sp

--- a/arch/arm/core/cortex_a_r/macro_priv.inc
+++ b/arch/arm/core/cortex_a_r/macro_priv.inc
@@ -26,6 +26,49 @@
         and \rreg0, #TPIDRURO_CURR_CPU
 .endm
 
+.macro fpu_exc_exit
+#if defined(CONFIG_FPU_SHARING)
+	/*
+	 * If the floating point context pointer is null, then a context was
+	 * saved so restore the float context from the exception stack frame.
+	 */
+	get_cpu r2
+	ldr r1, [r2, #___cpu_t_fp_ctx_OFFSET]
+	cmp r1, #0
+	beq vfp_restore\@
+
+	/*
+	 * If leaving the last interrupt context, remove the floating point
+	 * context pointer.
+	 */
+	cmp r0, #0
+	moveq r1, #0
+	streq r1, [r2, #___cpu_t_fp_ctx_OFFSET]
+	b vfp_exit\@
+
+vfp_restore\@:
+	add r3, sp, #___fpu_sf_t_fpscr_OFFSET
+	ldm r3, {r1, r2}
+	tst r2, #FPEXC_EN
+	beq vfp_exit\@
+
+	vmsr fpexc, r2
+	vmsr fpscr, r1
+	mov r3, sp
+	vldmia r3!, {s0-s15}
+#ifdef CONFIG_VFP_FEATURE_REGS_S64_D32
+	vldmia r3!, {d16-d31}
+#endif
+
+vfp_exit\@:
+	/* Leave the VFP disabled when leaving */
+	mov r1, #0
+	vmsr fpexc, r1
+
+	add sp, sp, #___fpu_t_SIZEOF
+#endif
+.endm
+
 .macro z_arm_cortex_ar_enter_exc
 	/*
 	 * Store r0-r3, r12, lr into the stack to construct an exception

--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -23,6 +23,8 @@
 
 _ASM_FILE_PROLOGUE
 
+GTEXT(__start_t32_workaround)
+GTEXT(__start_t32)
 GTEXT(z_arm_reset)
 GDATA(z_interrupt_stacks)
 GDATA(z_arm_svc_stack)
@@ -46,17 +48,14 @@ GTEXT(z_arm_platform_init)
  * setting up the system for running C code.
  *
  */
-SECTION_SUBSEC_FUNC(TEXT, _reset_section, z_arm_reset)
-SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
-    .align 8
+
 #if defined(CONFIG_AARCH32_ARMV8_R)
+/* NOP sled of 8 (2 bytes each) since the Boot ROM will actually start it 12 bytes
+ * before the indicated "Start" address. The start address needs to be 8 aligned. */
+SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start_t32_workaround)
+    .align 8
     .syntax unified
-
-#if defined(CONFIG_MCUBOOT)
     .thumb
-
-    /* NOP sled of 8 (2 bytes each) since the Boot ROM will actually start it 12 bytes
-     * before the indicated "Start" address. The start address needs to be 8 aligned. */
     nop
     nop
     nop // Actual start of execution
@@ -74,14 +73,17 @@ SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start_t32)
     nop
 
     /* Leave T32 (thumb) mode for A32 */
-    ldr r0, =Start_A32
+    ldr r0, =__start
     blx r0
     nop
     nop
-#endif /* CONFIG_MCUBOOT */
 
-Start_A32:
     .arm
+#endif /* defined(CONFIG_AARCH32_ARMV8_R) */
+
+SECTION_SUBSEC_FUNC(TEXT, _reset_section, z_arm_reset)
+SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
+#if defined(CONFIG_AARCH32_ARMV8_R)
     /* Check if we are starting in HYP mode */
     mrs r0, cpsr
     and r0, r0, #MODE_MASK
@@ -236,29 +238,24 @@ EL1_Reset_Handler:
     ldr r0, =arm_cpu_boot_params
 #if CONFIG_MP_MAX_NUM_CPUS > 1
     get_cpu_id r1
-
-    ldrex r2, [r0, #BOOT_PARAM_MPID_OFFSET]
-    cmp r2, #-1
-    bne 1f
-    strex r3, r1, [r0, #BOOT_PARAM_MPID_OFFSET]
-    cmp r3, #0
+    cmp r1, #0
     beq _primary_core
 
-1:
+_non_primary_core:
+    /* Spin here until the primary core releases this core. */
     dmb ld
     ldr r2, [r0, #BOOT_PARAM_MPID_OFFSET]
     cmp r1, r2
-    bne 1b
+    bne _non_primary_core
 
     /* we can now move on */
-    ldr r4, =arch_secondary_cpu_init
     ldr r5, [r0, #BOOT_PARAM_FIQ_SP_OFFSET]
     ldr r6, [r0, #BOOT_PARAM_IRQ_SP_OFFSET]
     ldr r7, [r0, #BOOT_PARAM_ABT_SP_OFFSET]
     ldr r8, [r0, #BOOT_PARAM_UDF_SP_OFFSET]
     ldr r9, [r0, #BOOT_PARAM_SVC_SP_OFFSET]
     ldr r10, [r0, #BOOT_PARAM_SYS_SP_OFFSET]
-    b 2f
+    b _configure_stack
 
 _primary_core:
 #endif
@@ -270,7 +267,7 @@ _primary_core:
     ldr r9, =(z_arm_svc_stack + CONFIG_ARMV7_SVC_STACK_SIZE)
     ldr r10, =(z_arm_sys_stack + CONFIG_ARMV7_SYS_STACK_SIZE)
 
-2:
+_configure_stack:
     /*
      * Configure stack.
      */
@@ -313,5 +310,14 @@ _primary_core:
     bl z_arm_tcm_disable_ecc
 #endif
 
+#if CONFIG_MP_MAX_NUM_CPUS > 1
+    get_cpu_id r1
+    cmp r1, #0
+    beq _primary_core_prep_c
+    ldr r4, =arch_secondary_cpu_init
+    b _jump_to_core_prep
+#endif
+_primary_core_prep_c:
     ldr r4, =z_prep_c
+_jump_to_core_prep:
     bx r4

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -65,15 +65,7 @@ BUILD_ASSERT(offsetof(struct boot_params, udf_sp) == BOOT_PARAM_UDF_SP_OFFSET);
 BUILD_ASSERT(offsetof(struct boot_params, svc_sp) == BOOT_PARAM_SVC_SP_OFFSET);
 BUILD_ASSERT(offsetof(struct boot_params, sys_sp) == BOOT_PARAM_SYS_SP_OFFSET);
 
-volatile struct boot_params arm_cpu_boot_params = {
-	.mpid = -1,
-	.irq_sp = (char *)(z_interrupt_stacks + CONFIG_ISR_STACK_SIZE),
-	.fiq_sp = (char *)(z_arm_fiq_stack + CONFIG_ARMV7_FIQ_STACK_SIZE),
-	.abt_sp = (char *)(z_arm_abort_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE),
-	.udf_sp = (char *)(z_arm_undef_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE),
-	.svc_sp = (char *)(z_arm_svc_stack + CONFIG_ARMV7_SVC_STACK_SIZE),
-	.sys_sp = (char *)(z_arm_sys_stack + CONFIG_ARMV7_SYS_STACK_SIZE),
-};
+volatile struct boot_params arm_cpu_boot_params;
 
 static const uint32_t cpu_node_list[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))};

--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -107,6 +107,7 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	iframe = (struct __basic_sf *)
 		((uintptr_t)iframe - sizeof(struct __fpu_sf));
 	memset(iframe, 0, sizeof(struct __fpu_sf));
+	((struct __fpu_sf*)iframe)->fpexc = FPEXC_EN;
 #endif
 
 	thread->callee_saved.psp = (uint32_t)iframe;

--- a/arch/arm/core/cortex_a_r/vector_table.S
+++ b/arch/arm/core/cortex_a_r/vector_table.S
@@ -12,6 +12,7 @@
 
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 #include "vector_table.h"
 #include "offsets_short.h"
 #include "macro_priv.inc"
@@ -34,24 +35,4 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 	ldr pc, =z_arm_nmi               /* FIQ            offset 0x1c */
 #else
 	ldr pc,=z_irq_spurious
-#endif
-
-
-#ifdef CONFIG_USE_SWITCH
-GTEXT(z_arm_cortex_ar_exit_exc)
-SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
-
-	/* decrement exception depth */
-	get_cpu r2
-	ldrb r1, [r2, #_cpu_offset_to_exc_depth]
-	sub r1, r1, #1
-	strb r1, [r2, #_cpu_offset_to_exc_depth]
-
-	/*
-	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
-	 * and return to the current thread.
-	 */
-	ldmia sp, {r0-r3, r12, lr}^
-	add sp, #24
-	rfeia sp!
 #endif

--- a/include/zephyr/arch/arm/cortex_a_r/exception.h
+++ b/include/zephyr/arch/arm/cortex_a_r/exception.h
@@ -36,7 +36,7 @@ struct __fpu_sf {
 	uint64_t d[16]; /* d16~d31 */
 #endif
 	uint32_t fpscr;
-	uint32_t undefined;
+	uint32_t fpexc;
 };
 #endif
 

--- a/soc/nxp/s32/s32ze/soc.c
+++ b/soc/nxp/s32/s32ze/soc.c
@@ -145,6 +145,10 @@ void z_arm_platform_init(void)
 			__set_SCTLR(__get_SCTLR() | SCTLR_I_Msk);
 			barrier_isync_fence_full();
 		}
+	} else {
+		/* Explicitly disable the ICACHE */
+		__set_SCTLR(__get_SCTLR() & (~SCTLR_I_Msk));
+		__ISB();
 	}
 
 	if (IS_ENABLED(CONFIG_DCACHE)) {
@@ -153,6 +157,10 @@ void z_arm_platform_init(void)
 			__set_SCTLR(__get_SCTLR() | SCTLR_C_Msk);
 			barrier_dsync_fence_full();
 		}
+	} else {
+		/* Explicitly disable the DCACHE */
+		__set_SCTLR(__get_SCTLR() & (~SCTLR_C_Msk));
+		__ISB();
 	}
 }
 

--- a/soc/nxp/s32/s32ze/soc.h
+++ b/soc/nxp/s32/s32ze/soc.h
@@ -71,4 +71,41 @@
 #define IP_MRU_6_BASE           IP_RTU1__MRU_2_BASE
 #define IP_MRU_7_BASE           IP_RTU1__MRU_3_BASE
 
+/* ME */
+#define MC_ME_BASE          0x41900000
+#define ME_SMU_OFFSET       0x100
+#define ME_RTU0_OFFSET      0x300
+#define ME_RTU1_OFFSET      0x500
+#define ME_CORE0_OFFSET     0x40
+#define ME_CORE1_OFFSET     0x60
+#define ME_CORE2_OFFSET     0x80
+#define ME_CORE3_OFFSET     0xa0
+#define ME_CORE_CONF_OFFSET 0x0
+#define ME_CORE_UPD_OFFSET  0x4
+#define ME_CORE_STAT_OFFSET 0x8
+#define ME_CORE_ADDR_OFFSET 0xc
+
+/* RGM */
+#define MC_RGM_BASE                0x41850000
+#define RGM_RTU0_OFFSET            0x48
+#define RGM_RTU1_OFFSET            0x50
+#define RGM_SUBSYS_RESET_MASK      0x1
+/* Periph 64 is the whole RTU0 subsystem
+ * Periph 65-68 in PRST1 are RTU0 Core 0-3
+ * Periph 128 is the whole RTU1 subsystem
+ * Periph 129-132 in PRST2 are RTU1 Core 0-3 */
+#define RGM_CORE_RESET_MASK(_core) (1 << ((_core) + 1))
+
+/* RTU GPR */
+#define RTU0_GPR_BASE                  0x76120000
+#define RTU1_GPR_BASE                  0x76920000
+#define RTU_GPR_CORE_CONF_OFFSET       0x0
+#define RTU_GPR_CONF_THUMB_MASK        (1 << 2)
+#define RTU_GPR_HALT_OFFSET            0x14
+#define RTU_GPR_HALT_MASK(_core)       (1 << (_core))
+#define RTU_GPR_ISOLATION_OFFSET       0xC
+#define RTU_GPR_ISOLATION_MASK(_core)  (0x10000111 << (_core))
+#define RTU_GPR_ISO_STATUS_OFFSET      0x1C
+#define RTU_GPR_ISO_STATUS_MASK(_core) (0x111 << (_core))
+
 #endif /* _NXP_S32_S32ZE_SOC_H_ */


### PR DESCRIPTION
Move z_arm_cortex_ar_exit_exc to the correct file.  

Handle VFP config and FPU state correctly in CortexR52 context switches.  

Support dcache/icache config flags disabled setting for the s32ze.  

Support multiple cores in cortex52/s32ze initilization.  
Support thumb mode when resetting in other cores.  
Hardcode core0 to be the primary boot core (remove reliance on initialized RAM).  
Perform s32ze core config/release operations for other cores when starting in core0 with CONFIG_MAX_NUM_CPUS > 1.  

NOTE: This requires DCACHE to be disabled since it is incoherent!!


